### PR TITLE
fix infinite loop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>Bridge-FitBit-Worker</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
 
     <properties>
         <aws.version>1.10.56</aws.version>

--- a/src/test/java/org/sagebionetworks/bridge/fitbit/bridge/FitBitUserIteratorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/fitbit/bridge/FitBitUserIteratorTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -20,6 +21,7 @@ import retrofit2.Response;
 import org.sagebionetworks.bridge.fitbit.worker.Constants;
 import org.sagebionetworks.bridge.rest.ClientManager;
 import org.sagebionetworks.bridge.rest.api.ForWorkersApi;
+import org.sagebionetworks.bridge.rest.exceptions.BridgeSDKException;
 import org.sagebionetworks.bridge.rest.model.ForwardCursorStringList;
 import org.sagebionetworks.bridge.rest.model.OAuthAccessToken;
 
@@ -44,7 +46,8 @@ public class FitBitUserIteratorTest {
     @Test
     public void testWith0Users() throws Exception {
         // mockApiWithPage() with start=0 and end=-1 does what we want, even though it reads funny.
-        mockApiWithPage(null, 0, -1, null);
+        mockApiWithPage(null, 0, -1, null,
+                FitBitUserIterator.DEFAULT_PAGESIZE);
 
         // Verify iterator has no users
         FitBitUserIterator iter = new FitBitUserIterator(mockClientManager, STUDY_ID);
@@ -53,39 +56,43 @@ public class FitBitUserIteratorTest {
 
     @Test
     public void testWith1User() throws Exception {
-        mockApiWithPage(null, 0, 0, null);
+        mockApiWithPage(null, 0, 0, null, FitBitUserIterator.DEFAULT_PAGESIZE);
         testIterator(1);
     }
 
     @Test
     public void testWith1Page() throws Exception {
-        mockApiWithPage(null, 0, 9, null);
+        mockApiWithPage(null, 0, 9, null, FitBitUserIterator.DEFAULT_PAGESIZE);
         testIterator(10);
     }
 
     @Test
     public void testWith1PagePlus1User() throws Exception {
-        mockApiWithPage(null, 0, 9, "page2");
-        mockApiWithPage("page2", 10, 10, null);
+        mockApiWithPage(null, 0, 9, "page2",
+                FitBitUserIterator.DEFAULT_PAGESIZE);
+        mockApiWithPage("page2", 10, 10, null,
+                FitBitUserIterator.DEFAULT_PAGESIZE);
         testIterator(11);
     }
 
     @Test
     public void testWith2Pages() throws Exception {
-        mockApiWithPage(null, 0, 9, "page2");
-        mockApiWithPage("page2", 10, 19, null);
+        mockApiWithPage(null, 0, 9, "page2",
+                FitBitUserIterator.DEFAULT_PAGESIZE);
+        mockApiWithPage("page2", 10, 19, null,
+                FitBitUserIterator.DEFAULT_PAGESIZE);
         testIterator(20);
     }
 
     @Test
     public void hasNextDoesNotCallServerOrAdvanceIterator() throws Exception {
         // Create page with 2 items
-        mockApiWithPage(null, 0, 1, null);
+        mockApiWithPage(null, 0, 1, null, FitBitUserIterator.DEFAULT_PAGESIZE);
 
         // Create iterator. Verify initial call to server.
         FitBitUserIterator iter = new FitBitUserIterator(mockClientManager, STUDY_ID);
         verify(mockApi).getHealthCodesGrantingOAuthAccess(STUDY_ID, Constants.FITBIT_VENDOR_ID,
-                FitBitUserIterator.PAGESIZE, null);
+                FitBitUserIterator.DEFAULT_PAGESIZE, null);
 
         // Make a few extra calls to hasNext(). Verify that no server calls are made
         assertTrue(iter.hasNext());
@@ -98,48 +105,126 @@ public class FitBitUserIteratorTest {
         assertFitBitUserForIndex(0, firstUser);
     }
 
-    // branch coverage
     @Test(expectedExceptions = RuntimeException.class)
-    public void errorGettingPage() throws Exception {
+    public void errorGettingFirstPage() throws Exception {
         // Mock page call to throw
         Call<ForwardCursorStringList> mockPageCall = mock(Call.class);
         when(mockPageCall.execute()).thenThrow(IOException.class);
 
         when(mockApi.getHealthCodesGrantingOAuthAccess(STUDY_ID, Constants.FITBIT_VENDOR_ID,
-                FitBitUserIterator.PAGESIZE, null)).thenReturn(mockPageCall);
+                FitBitUserIterator.DEFAULT_PAGESIZE, null)).thenReturn(mockPageCall);
 
         // Execute
         new FitBitUserIterator(mockClientManager, STUDY_ID);
     }
 
-    // branch coverage
-    @Test(expectedExceptions = RuntimeException.class)
-    public void errorGettingToken() throws Exception {
-        // Mock page call to return one item
-        ForwardCursorStringList forwardCursorStringList = new ForwardCursorStringList();
-        forwardCursorStringList.addItemsItem(HEALTH_CODE_PREFIX);
-        forwardCursorStringList.setHasNext(false);
-        forwardCursorStringList.setNextPageOffsetKey(null);
+    @Test
+    public void errorGettingSecondPageRetries() throws Exception {
+        // For simplicity, pageSize=1, 3 pages.
+        mockApiWithPage(null, 0, 0, "page2", 1);
 
-        Response<ForwardCursorStringList> pageResponse = Response.success(forwardCursorStringList);
+        Response<ForwardCursorStringList> secondPageResponse = makePageResponse(1, 1,
+                "page3");
+        Call<ForwardCursorStringList> mockSecondPageCall = mock(Call.class);
+        when(mockSecondPageCall.execute()).thenThrow(IOException.class).thenReturn(secondPageResponse);
+        when(mockApi.getHealthCodesGrantingOAuthAccess(STUDY_ID, Constants.FITBIT_VENDOR_ID, 1, "page2"))
+                .thenReturn(mockSecondPageCall);
 
+        Response<OAuthAccessToken> token1Response = makeTokenResponse(1);
+        Call<OAuthAccessToken> mockToken1Call = mock(Call.class);
+        when(mockToken1Call.execute()).thenReturn(token1Response);
+        when(mockApi.getOAuthAccessToken(STUDY_ID, Constants.FITBIT_VENDOR_ID, HEALTH_CODE_PREFIX + 1))
+                .thenReturn(mockToken1Call);
+
+        mockApiWithPage("page3", 2, 2, null, 1);
+
+        // Execute and validate
+        errorTest(1, false);
+    }
+
+    @Test
+    public void tokenErrorIoExceptionRetries() throws Exception {
+        setupTokenCallErrorTest(new IOException());
+        errorTest(3, false);
+    }
+
+    @Test
+    public void tokenError400DoesntRetry() throws Exception {
+        setupTokenCallErrorTest(new BridgeSDKException("test error", 400));
+        errorTest(3, true);
+    }
+
+    @Test
+    public void tokenError500Retries() throws Exception {
+        setupTokenCallErrorTest(new BridgeSDKException("test error", 500));
+        errorTest(3, false);
+    }
+
+    // branch coverage: Bridge doesn't throw 300s, but this tests a branch that would otherwise not be tested.
+    @Test
+    public void tokenError300Retries() throws Exception {
+        setupTokenCallErrorTest(new BridgeSDKException("test error", 300));
+        errorTest(3, false);
+    }
+
+    private void setupTokenCallErrorTest(Exception ex) throws Exception {
+        // For simplicity, 1 page, 3 users, pageSize=3.
+        Response<ForwardCursorStringList> pageResponse = makePageResponse(0, 2, null);
         Call<ForwardCursorStringList> mockPageCall = mock(Call.class);
         when(mockPageCall.execute()).thenReturn(pageResponse);
+        when(mockApi.getHealthCodesGrantingOAuthAccess(STUDY_ID, Constants.FITBIT_VENDOR_ID, 3, null))
+                .thenReturn(mockPageCall);
 
-        when(mockApi.getHealthCodesGrantingOAuthAccess(STUDY_ID, Constants.FITBIT_VENDOR_ID,
-                FitBitUserIterator.PAGESIZE, null)).thenReturn(mockPageCall);
+        Response<OAuthAccessToken> token0Response = makeTokenResponse(0);
+        Call<OAuthAccessToken> mockToken0Call = mock(Call.class);
+        when(mockToken0Call.execute()).thenReturn(token0Response);
+        when(mockApi.getOAuthAccessToken(STUDY_ID, Constants.FITBIT_VENDOR_ID, HEALTH_CODE_PREFIX + 0))
+                .thenReturn(mockToken0Call);
 
-        // Mock token call to throw
-        Call<OAuthAccessToken> mockTokenCall = mock(Call.class);
-        when(mockTokenCall.execute()).thenThrow(IOException.class);
+        Response<OAuthAccessToken> token1Response = makeTokenResponse(1);
+        Call<OAuthAccessToken> mockToken1Call = mock(Call.class);
+        when(mockToken1Call.execute()).thenThrow(ex).thenReturn(token1Response);
+        when(mockApi.getOAuthAccessToken(STUDY_ID, Constants.FITBIT_VENDOR_ID, HEALTH_CODE_PREFIX + 1))
+                .thenReturn(mockToken1Call);
 
-        when(mockApi.getOAuthAccessToken(STUDY_ID, Constants.FITBIT_VENDOR_ID, HEALTH_CODE_PREFIX)).thenReturn(
-                mockTokenCall);
+        Response<OAuthAccessToken> token2Response = makeTokenResponse(2);
+        Call<OAuthAccessToken> mockToken2Call = mock(Call.class);
+        when(mockToken2Call.execute()).thenReturn(token2Response);
+        when(mockApi.getOAuthAccessToken(STUDY_ID, Constants.FITBIT_VENDOR_ID, HEALTH_CODE_PREFIX + 2))
+                .thenReturn(mockToken2Call);
+    }
 
-        // Execute
-        FitBitUserIterator iter = new FitBitUserIterator(mockClientManager, STUDY_ID);
+    private void errorTest(int pageSize, boolean skipsErrorUser) {
+        // User 1 always fails. Depending on test setup, we might retry on the next loop, or we might skip.
+
+        // Create iterator
+        FitBitUserIterator iter = new FitBitUserIterator(mockClientManager, STUDY_ID, pageSize);
+
+        // User 0
         assertTrue(iter.hasNext());
-        iter.next();
+        FitBitUser user0 = iter.next();
+        assertFitBitUserForIndex(0, user0);
+
+        // User 1 throws, then succeeds
+        assertTrue(iter.hasNext());
+        try {
+            iter.next();
+            fail("expected exception");
+        } catch (RuntimeException ex) {
+            // expected exception
+        }
+        if (!skipsErrorUser) {
+            FitBitUser user1 = iter.next();
+            assertFitBitUserForIndex(1, user1);
+        }
+
+        // User 2
+        assertTrue(iter.hasNext());
+        FitBitUser user2 = iter.next();
+        assertFitBitUserForIndex(2, user2);
+
+        // End
+        assertFalse(iter.hasNext());
     }
 
     // branch coverage
@@ -147,7 +232,7 @@ public class FitBitUserIteratorTest {
             "No more tokens left for study " + STUDY_ID)
     public void extraCallToNextThrows() throws Exception {
         // Mock page with just 1 item
-        mockApiWithPage(null, 0, 0, null);
+        mockApiWithPage(null, 0, 0, null, FitBitUserIterator.DEFAULT_PAGESIZE);
 
         // next() twice throws
         FitBitUserIterator iter = new FitBitUserIterator(mockClientManager, STUDY_ID);
@@ -155,7 +240,26 @@ public class FitBitUserIteratorTest {
         iter.next();
     }
 
-    private void mockApiWithPage(String curOffsetKey, int start, int end, String nextPageOffsetKey) throws Exception {
+    private void mockApiWithPage(String curOffsetKey, int start, int end, String nextPageOffsetKey, int pageSize)
+            throws Exception {
+        // Mock page call.
+        Response<ForwardCursorStringList> pageResponse = makePageResponse(start, end, nextPageOffsetKey);
+        Call<ForwardCursorStringList> mockPageCall = mock(Call.class);
+        when(mockPageCall.execute()).thenReturn(pageResponse);
+        when(mockApi.getHealthCodesGrantingOAuthAccess(STUDY_ID, Constants.FITBIT_VENDOR_ID, pageSize, curOffsetKey))
+                .thenReturn(mockPageCall);
+
+        // Mock token calls
+        for (int i = start; i <= end; i++) {
+            Response<OAuthAccessToken> tokenResponse = makeTokenResponse(i);
+            Call<OAuthAccessToken> mockTokenCall = mock(Call.class);
+            when(mockTokenCall.execute()).thenReturn(tokenResponse);
+            when(mockApi.getOAuthAccessToken(STUDY_ID, Constants.FITBIT_VENDOR_ID, HEALTH_CODE_PREFIX + i))
+                    .thenReturn(mockTokenCall);
+        }
+    }
+
+    private Response<ForwardCursorStringList> makePageResponse(int start, int end, String nextPageOffsetKey) {
         ForwardCursorStringList forwardCursorStringList = new ForwardCursorStringList();
 
         // Make page elements
@@ -169,31 +273,20 @@ public class FitBitUserIteratorTest {
         forwardCursorStringList.setHasNext(nextPageOffsetKey != null);
         forwardCursorStringList.setNextPageOffsetKey(nextPageOffsetKey);
 
-        // Mock API to return this.
+        // Mock Response and Call to return this.
         Response<ForwardCursorStringList> pageResponse = Response.success(forwardCursorStringList);
+        return pageResponse;
+    }
 
-        Call<ForwardCursorStringList> mockPageCall = mock(Call.class);
-        when(mockPageCall.execute()).thenReturn(pageResponse);
+    private Response<OAuthAccessToken> makeTokenResponse(int idx) {
+        // Must mock access token because there are no setters.
+        OAuthAccessToken token = mock(OAuthAccessToken.class);
+        when(token.getAccessToken()).thenReturn(ACCESS_TOKEN_PREFIX + idx);
+        when(token.getProviderUserId()).thenReturn(USER_ID_PREFIX + idx);
 
-        when(mockApi.getHealthCodesGrantingOAuthAccess(STUDY_ID, Constants.FITBIT_VENDOR_ID,
-                FitBitUserIterator.PAGESIZE, curOffsetKey)).thenReturn(mockPageCall);
-
-        // Mock token calls
-        for (int i = start; i <= end; i++) {
-            // Must mock access token because there are no setters.
-            OAuthAccessToken token = mock(OAuthAccessToken.class);
-            when(token.getAccessToken()).thenReturn(ACCESS_TOKEN_PREFIX + i);
-            when(token.getProviderUserId()).thenReturn(USER_ID_PREFIX + i);
-
-            // Mock API to return this
-            Response<OAuthAccessToken> tokenResponse = Response.success(token);
-
-            Call<OAuthAccessToken> mockTokenCall = mock(Call.class);
-            when(mockTokenCall.execute()).thenReturn(tokenResponse);
-
-            when(mockApi.getOAuthAccessToken(STUDY_ID, Constants.FITBIT_VENDOR_ID, HEALTH_CODE_PREFIX + i))
-                    .thenReturn(mockTokenCall);
-        }
+        // Mock Response and Call to return this
+        Response<OAuthAccessToken> tokenResponse = Response.success(token);
+        return tokenResponse;
     }
 
     private void testIterator(int expectedCount) {


### PR DESCRIPTION
There is a bug where if Bridge Server throws when retrieving the OAuth Access Grant, the FitBitUserIterator won't advance, and it'll end up retrying infinitely. This is a problem if it's a deterministic 4XX error. This can happen, for example, if two test accounts on Bridge share the same FitBit account. Only one of those accounts can have an OAuth grant, and the other will perpetually throw 404s.

This code change detects 4XX errors and advances the iterator if that happens, preventing a possible infinite loop.

Note: This doesn't handle the case where, for example, Bridge Server is unavailable and throws 503s for extended periods of time. See https://sagebionetworks.jira.com/browse/BRIDGE-2055

Manually tested fix:
* Register the FitBit OAuth token to two separate Bridge accounts.
* Wait for the tokens to expire, or manually edit the token expiration of both tokens to be in the past.
* Export.

Updated unit tests.