### PR TITLE
add heart rate

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>Bridge-FitBit-Worker</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
 
     <properties>
         <aws.version>1.10.56</aws.version>

--- a/src/main/resources/schema.json
+++ b/src/main/resources/schema.json
@@ -141,5 +141,44 @@
                 ]
             }
         ]
+    },
+    {
+        "endpointId":"HeartRate",
+        "url":"https://api.fitbit.com/1/user/%s/activities/heart/date/%s/1d/1sec.json",
+        "urlParameters":["USER_ID", "DATE"],
+        "tables":[
+            {
+                "tableKey":"activities-heart",
+                "columns":[
+                    {
+                        "columnId":"dateTime",
+                        "columnType":"STRING",
+                        "maxLength":10
+                    },
+                    {
+                        "columnId":"value",
+                        "columnType":"LARGETEXT"
+                    }
+                ]
+            },
+            {
+                "tableKey":"activities-heart-intraday",
+                "columns":[
+                    {
+                        "columnId":"dataset",
+                        "columnType":"LARGETEXT"
+                    },
+                    {
+                        "columnId":"datasetInterval",
+                        "columnType":"INTEGER"
+                    },
+                    {
+                        "columnId":"datasetType",
+                        "columnType":"STRING",
+                        "maxLength":6
+                    }
+                ]
+            }
+        ]
     }
 ]


### PR DESCRIPTION
Adds heart rate to FitBit Worker configs. See https://dev.fitbit.com/build/reference/web-api/heart-rate/

Testing done:
* Manually tested and verified that heart rate summary and intra day time series (1sec granularity) are being exported to Synapse.
* Manually tested that, if I configure the app to only request heartrate permissions and not activity, the 403 on activity summary does not prevent heart rate from being exported.