### PR TITLE
move heart rate data to file handle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>Bridge-FitBit-Worker</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
 
     <properties>
         <aws.version>1.10.56</aws.version>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>bridge-base</artifactId>
-            <version>2.7.8</version>
+            <version>2.7.9</version>
         </dependency>
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>

--- a/src/main/java/org/sagebionetworks/bridge/fitbit/worker/TableProcessor.java
+++ b/src/main/java/org/sagebionetworks/bridge/fitbit/worker/TableProcessor.java
@@ -150,7 +150,9 @@ public class TableProcessor {
             setSynapseTableIdToDdb(study.getIdentifier(), tableId, newSynapseTableId);
             return newSynapseTableId;
         } else {
-            synapseHelper.safeUpdateTable(synapseTableId, columnModelList);
+            // For backwards compatibility, we set mergeDeletedFields=true, so that any fields in the table not in our
+            // schema are retained transparently.
+            synapseHelper.safeUpdateTable(synapseTableId, columnModelList, true);
             return synapseTableId;
         }
     }

--- a/src/main/java/org/sagebionetworks/bridge/fitbit/worker/UserProcessor.java
+++ b/src/main/java/org/sagebionetworks/bridge/fitbit/worker/UserProcessor.java
@@ -1,6 +1,8 @@
 package org.sagebionetworks.bridge.fitbit.worker;
 
+import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -8,27 +10,48 @@ import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.http.client.fluent.Request;
+import org.joda.time.DateTime;
+import org.sagebionetworks.client.exceptions.SynapseException;
+import org.sagebionetworks.repo.model.file.FileHandle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import org.sagebionetworks.bridge.file.FileHelper;
 import org.sagebionetworks.bridge.fitbit.bridge.FitBitUser;
 import org.sagebionetworks.bridge.fitbit.schema.ColumnSchema;
 import org.sagebionetworks.bridge.fitbit.schema.EndpointSchema;
 import org.sagebionetworks.bridge.fitbit.schema.TableSchema;
 import org.sagebionetworks.bridge.fitbit.schema.UrlParameterType;
-import org.sagebionetworks.bridge.fitbit.util.Utils;
 import org.sagebionetworks.bridge.json.DefaultObjectMapper;
+import org.sagebionetworks.bridge.synapse.SynapseHelper;
 
 /** The User Processor downloads data from the FitBit Web API and collates the data into tables. */
 @Component
 public class UserProcessor {
     private static final Logger LOG = LoggerFactory.getLogger(UserProcessor.class);
 
+    private FileHelper fileHelper;
+    private SynapseHelper synapseHelper;
+
+    /** File Helper, used to write files to the temp directory before uploading as file handles. */
+    @Autowired
+    public final void setFileHelper(FileHelper fileHelper) {
+        this.fileHelper = fileHelper;
+    }
+
+    /** Synapse Helper, used to upload files as file handles to Synapse. */
+    @Autowired
+    public final void setSynapseHelper(SynapseHelper synapseHelper) {
+        this.synapseHelper = synapseHelper;
+    }
+
     /** Processes the given endpoint for the given user. This is the main entry point into the User Processor. */
     public void processEndpointForUser(RequestContext ctx, FitBitUser user, EndpointSchema endpointSchema)
-            throws IOException {
+            throws IOException, SynapseException {
         // Generate url parameters
         List<String> resolvedUrlParamList = new ArrayList<>();
         for (UrlParameterType oneUrlParam : endpointSchema.getUrlParameters()) {
@@ -79,7 +102,7 @@ public class UserProcessor {
 
     // Helper to process a single row of FitBit data.
     private void processTableRowForUser(RequestContext ctx, FitBitUser user, EndpointSchema endpointSchema,
-            TableSchema tableSchema, JsonNode rowNode) {
+            TableSchema tableSchema, JsonNode rowNode) throws IOException, SynapseException {
         String tableId = endpointSchema.getEndpointId() + '.' + tableSchema.getTableKey();
         PopulatedTable populatedTable = ctx.getPopulatedTablesById().get(tableId);
         Map<String, String> rowValueMap = new HashMap<>();
@@ -95,7 +118,7 @@ public class UserProcessor {
                 warnWrapper("Unexpected column " + oneColumnName + " in table " + tableId + " for user " +
                         user.getHealthCode());
             } else {
-                Object value = Utils.serializeJsonForColumn(columnValueNode, columnSchema);
+                Object value = serializeJsonForColumn(ctx, columnValueNode, columnSchema);
                 if (value != null) {
                     rowValueMap.put(oneColumnName, value.toString());
                 }
@@ -110,6 +133,108 @@ public class UserProcessor {
             // Add the row to the table
             populatedTable.getRowList().add(rowValueMap);
         }
+    }
+
+    // Helper method to serialize a JsonNode to write to the given Column.
+    // Visible for testing.
+    String serializeJsonForColumn(RequestContext ctx, JsonNode node, ColumnSchema columnSchema)
+            throws IOException, SynapseException {
+        String columnId = columnSchema.getColumnId();
+
+        // Short-cut: null check.
+        if (node == null || node.isNull()) {
+            return null;
+        }
+
+        // Canonicalize into an object.
+        Object value = null;
+        switch (columnSchema.getColumnType()) {
+            case BOOLEAN:
+                if (node.isBoolean()) {
+                    value = node.booleanValue();
+                } else {
+                    LOG.warn("Expected boolean for column " + columnId + ", got " + node.getNodeType().name());
+                }
+                break;
+            case DATE:
+                // Currently, all dates from FitBit web API are in UTC, so we can just use epoch milliseconds,
+                // which is what Synapse expects anyway.
+                if (node.isTextual()) {
+                    String dateTimeStr = node.textValue();
+                    try {
+                        value = DateTime.parse(dateTimeStr).getMillis();
+                    } catch (IllegalArgumentException ex) {
+                        LOG.warn("Invalid DateTime format " + dateTimeStr);
+                    }
+                } else {
+                    LOG.warn("Expected string for column " + columnId + ", got " + node.getNodeType().name());
+                }
+                break;
+            case DOUBLE:
+                if (node.isNumber()) {
+                    value = node.decimalValue().toPlainString();
+                } else {
+                    LOG.warn("Expected number for column " + columnId + ", got " + node.getNodeType().name());
+                }
+                break;
+            case FILEHANDLEID:
+                // Write value to temp file on disk.
+                String tempFileName = columnId + RandomStringUtils.randomAlphabetic(4);
+                File fileToUpload = fileHelper.newFile(ctx.getTmpDir(), tempFileName);
+                try (OutputStream fileOutputStream = fileHelper.getOutputStream(fileToUpload)) {
+                    DefaultObjectMapper.INSTANCE.writeValue(fileOutputStream, node);
+                }
+
+                // Upload file handle. Value is the file handle ID.
+                FileHandle fileHandle = synapseHelper.createFileHandleWithRetry(fileToUpload);
+                value = fileHandle.getId();
+
+                // Finally, delete the temp file.
+                fileHelper.deleteFile(fileToUpload);
+                break;
+            case INTEGER:
+                if (node.isNumber()) {
+                    value = node.longValue();
+                } else {
+                    LOG.warn("Expected number for column " + columnId + ", got " + node.getNodeType().name());
+                }
+                break;
+            case LARGETEXT:
+                // LargeText is used for when the value is an array or an object. In this case, we want to
+                // write the JSON verbatim to Synapse.
+                value = node;
+                break;
+            case STRING:
+                String textValue;
+                if (node.isTextual()) {
+                    textValue = node.textValue();
+                } else {
+                    textValue = node.toString();
+                }
+
+                // Strings have a max length. If the string is too long, truncate it.
+                int valueLength = textValue.length();
+                int maxLength = columnSchema.getMaxLength();
+                if (valueLength > maxLength) {
+                    LOG.warn("Truncating value of length " + valueLength + " to max length " + maxLength +
+                            " for column " + columnId);
+                    textValue = textValue.substring(0, maxLength);
+                }
+                value = textValue;
+                break;
+            default:
+                LOG.warn("Unexpected type " + columnSchema.getColumnType().name() + " for column " + columnId);
+                break;
+        }
+
+        // If the canonicalized value is null (possibly because of type errors), return null instead of converting to
+        // a string.
+        if (value == null) {
+            return null;
+        }
+
+        // Convert to string.
+        return String.valueOf(value);
     }
 
     // Abstracts away the HTTP call to FitBit Web API.

--- a/src/main/resources/schema.json
+++ b/src/main/resources/schema.json
@@ -166,7 +166,7 @@
                 "columns":[
                     {
                         "columnId":"dataset",
-                        "columnType":"LARGETEXT"
+                        "columnType":"FILEHANDLEID"
                     },
                     {
                         "columnId":"datasetInterval",

--- a/src/test/java/org/sagebionetworks/bridge/fitbit/util/UtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/fitbit/util/UtilsTest.java
@@ -7,53 +7,26 @@ import static org.testng.Assert.assertTrue;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.math.BigDecimal;
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.BooleanNode;
-import com.fasterxml.jackson.databind.node.DecimalNode;
-import com.fasterxml.jackson.databind.node.IntNode;
-import com.fasterxml.jackson.databind.node.LongNode;
-import com.fasterxml.jackson.databind.node.NullNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.sagebionetworks.repo.model.table.ColumnModel;
 import org.sagebionetworks.repo.model.table.ColumnType;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.fitbit.schema.ColumnSchema;
 import org.sagebionetworks.bridge.fitbit.schema.TableSchema;
 import org.sagebionetworks.bridge.fitbit.worker.Constants;
 import org.sagebionetworks.bridge.fitbit.worker.PopulatedTable;
-import org.sagebionetworks.bridge.json.DefaultObjectMapper;
 import org.sagebionetworks.bridge.rest.model.OAuthProvider;
 import org.sagebionetworks.bridge.rest.model.Study;
 
 public class UtilsTest {
-    private static final String COLUMN_ID = "my-column";
     private static final long DATA_ACCESS_TEAM_ID = 1234L;
     private static final String PROJECT_ID = "my-project";
     private static final String TABLE_KEY = "my-table-key";
     private static final String TABLE_ID = "my-table-id";
-
-    private static final ColumnSchema BOOLEAN_COLUMN = new ColumnSchema.Builder().withColumnId(COLUMN_ID)
-            .withColumnType(ColumnType.BOOLEAN).build();
-    private static final ColumnSchema DATE_COLUMN = new ColumnSchema.Builder().withColumnId(COLUMN_ID)
-            .withColumnType(ColumnType.DATE).build();
-    private static final ColumnSchema DOUBLE_COLUMN = new ColumnSchema.Builder().withColumnId(COLUMN_ID)
-            .withColumnType(ColumnType.DOUBLE).build();
-    private static final ColumnSchema INTEGER_COLUMN = new ColumnSchema.Builder().withColumnId(COLUMN_ID)
-            .withColumnType(ColumnType.INTEGER).build();
-    private static final ColumnSchema LARGETEXT_COLUMN = new ColumnSchema.Builder().withColumnId(COLUMN_ID)
-            .withColumnType(ColumnType.LARGETEXT).build();
-    private static final ColumnSchema STRING_COLUMN = new ColumnSchema.Builder().withColumnId(COLUMN_ID)
-            .withColumnType(ColumnType.STRING).withMaxLength(10).build();
-    private static final ColumnSchema UNSUPPORTED_COLUMN = new ColumnSchema.Builder().withColumnId(COLUMN_ID)
-            .withColumnType(ColumnType.FILEHANDLEID).build();
 
     @Test
     public void getAllColumnsForTable() {
@@ -125,45 +98,6 @@ public class UtilsTest {
         Study study = new Study().synapseProjectId(PROJECT_ID).synapseDataAccessTeamId(DATA_ACCESS_TEAM_ID)
                 .oAuthProviders(ImmutableMap.of());
         assertFalse(Utils.isStudyConfigured(study));
-    }
-
-    @DataProvider(name = "serializeDataProvider")
-    public Object[][] serializeDataProvider() {
-        return new Object[][] {
-                { null, STRING_COLUMN, null },
-                { NullNode.instance, STRING_COLUMN, null },
-                { new IntNode(1), BOOLEAN_COLUMN, null },
-                { new TextNode("true"), BOOLEAN_COLUMN, null },
-                { BooleanNode.TRUE, BOOLEAN_COLUMN, "true" },
-                { new LongNode(1513152387123L), DATE_COLUMN, null },
-                { new TextNode("December 12, 2017 at 18:56:51"), DATE_COLUMN, null },
-                { new TextNode("2017-12-12T18:56:51.098Z"), DATE_COLUMN, "1513105011098" },
-                { new TextNode("3.14159"), DOUBLE_COLUMN, null },
-                { new DecimalNode(new BigDecimal("3.14159")), DOUBLE_COLUMN, "3.14159" },
-                { new IntNode(3), DOUBLE_COLUMN, "3" },
-                { new TextNode("42"), INTEGER_COLUMN, null },
-                { new IntNode(42), INTEGER_COLUMN, "42" },
-                { new DecimalNode(new BigDecimal("3.14159")), INTEGER_COLUMN, "3" },
-                { new IntNode(1024), STRING_COLUMN, "1024" },
-                { new TextNode("foo"), STRING_COLUMN, "foo" },
-                { new TextNode("aaaabbbbccccdddd"), STRING_COLUMN, "aaaabbbbcc" },
-                { new TextNode("foo"), UNSUPPORTED_COLUMN, null },
-        };
-    }
-
-    @Test(dataProvider = "serializeDataProvider")
-    public void serialize(JsonNode node, ColumnSchema columnSchema, String expected) {
-        String result = Utils.serializeJsonForColumn(node, columnSchema);
-        assertEquals(result, expected);
-    }
-
-    @Test
-    public void serializeLargeText() {
-        ObjectNode node = DefaultObjectMapper.INSTANCE.createObjectNode();
-        node.put("foo", "foo-value");
-        node.put("bar", "bar-value");
-        String result = Utils.serializeJsonForColumn(node, LARGETEXT_COLUMN);
-        assertEquals(result, node.toString());
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/fitbit/worker/TableProcessorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/fitbit/worker/TableProcessorTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.fitbit.worker;
 
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -127,7 +128,8 @@ public class TableProcessorTest {
         verify(mockDdbTablesMap, never()).putItem(any(Item.class));
 
         ArgumentCaptor<List> columnModelListCaptor = ArgumentCaptor.forClass(List.class);
-        verify(mockSynapseHelper).safeUpdateTable(eq(SYNAPSE_TABLE_ID), columnModelListCaptor.capture());
+        verify(mockSynapseHelper).safeUpdateTable(eq(SYNAPSE_TABLE_ID), columnModelListCaptor.capture(),
+                eq(true));
         validateColumnModelList(columnModelListCaptor.getValue());
     }
 
@@ -156,7 +158,7 @@ public class TableProcessorTest {
         validateCleanFileSystem();
 
         // Verify back-ends
-        verify(mockSynapseHelper, never()).safeUpdateTable(any(), any());
+        verify(mockSynapseHelper, never()).safeUpdateTable(any(), any(), anyBoolean());
 
         ArgumentCaptor<List> columnModelListCaptor = ArgumentCaptor.forClass(List.class);
         verify(mockSynapseHelper).createTableWithColumnsAndAcls(columnModelListCaptor.capture(),

--- a/src/test/java/org/sagebionetworks/bridge/fitbit/worker/UserProcessorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/fitbit/worker/UserProcessorTest.java
@@ -6,35 +6,70 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import java.io.File;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.BooleanNode;
+import com.fasterxml.jackson.databind.node.DecimalNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.LongNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import org.mockito.ArgumentCaptor;
+import org.sagebionetworks.repo.model.file.FileHandle;
 import org.sagebionetworks.repo.model.table.ColumnType;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import org.sagebionetworks.bridge.file.InMemoryFileHelper;
 import org.sagebionetworks.bridge.fitbit.bridge.FitBitUser;
 import org.sagebionetworks.bridge.fitbit.schema.ColumnSchema;
 import org.sagebionetworks.bridge.fitbit.schema.EndpointSchema;
 import org.sagebionetworks.bridge.fitbit.schema.TableSchema;
 import org.sagebionetworks.bridge.fitbit.schema.UrlParameterType;
+import org.sagebionetworks.bridge.json.DefaultObjectMapper;
 import org.sagebionetworks.bridge.rest.model.Study;
+import org.sagebionetworks.bridge.synapse.SynapseHelper;
 
 public class UserProcessorTest {
     private static final String COLUMN_ID = "my-column";
     private static final String DATE_STRING = "2017-12-12";
     private static final String ENDPOINT_ID = "my-endpoint";
+    private static final String FILEHANDLE_ID = "my-file-handle";
     private static final String IGNORED_KEY = "ignored-key";
     private static final String TABLE_KEY = "table-key";
     private static final String URL = "http://example.com/users/my-user/date/2017-12-12";
     private static final String URL_PATTERN = "http://example.com/users/%s/date/%s";
+
+    private static final ColumnSchema BOOLEAN_COLUMN = new ColumnSchema.Builder().withColumnId(COLUMN_ID)
+            .withColumnType(ColumnType.BOOLEAN).build();
+    private static final ColumnSchema DATE_COLUMN = new ColumnSchema.Builder().withColumnId(COLUMN_ID)
+            .withColumnType(ColumnType.DATE).build();
+    private static final ColumnSchema DOUBLE_COLUMN = new ColumnSchema.Builder().withColumnId(COLUMN_ID)
+            .withColumnType(ColumnType.DOUBLE).build();
+    private static final ColumnSchema FILEHANDLE_COLUMN = new ColumnSchema.Builder().withColumnId(COLUMN_ID)
+            .withColumnType(ColumnType.FILEHANDLEID).build();
+    private static final ColumnSchema INTEGER_COLUMN = new ColumnSchema.Builder().withColumnId(COLUMN_ID)
+            .withColumnType(ColumnType.INTEGER).build();
+    private static final ColumnSchema LARGETEXT_COLUMN = new ColumnSchema.Builder().withColumnId(COLUMN_ID)
+            .withColumnType(ColumnType.LARGETEXT).build();
+    private static final ColumnSchema STRING_COLUMN = new ColumnSchema.Builder().withColumnId(COLUMN_ID)
+            .withColumnType(ColumnType.STRING).withMaxLength(10).build();
+    private static final ColumnSchema UNSUPPORTED_COLUMN = new ColumnSchema.Builder().withColumnId(COLUMN_ID)
+            .withColumnType(ColumnType.LINK).build();
 
     private static final String STUDY_ID = "my-study";
     private static final Study STUDY = new Study().identifier(STUDY_ID);
@@ -61,23 +96,36 @@ public class UserProcessorTest {
     }
 
     private RequestContext ctx;
+    private InMemoryFileHelper inMemoryFileHelper;
+    private byte[] uploadedFileBytes;
     private String mockHttpResponse;
+    private SynapseHelper mockSynapseHelper;
     private UserProcessor processor;
 
     @BeforeMethod
     public void setup() throws Exception {
-        // Reset mockHttpResponse, because sometimes TestNG doesn't.
+        // Reset test params, because sometimes TestNG doesn't.
         mockHttpResponse = null;
+        uploadedFileBytes = null;
+
+        // Create in-memory file helper with temp dir.
+        inMemoryFileHelper = new InMemoryFileHelper();
+        File tempDir = inMemoryFileHelper.createTempDir();
+
+        // Mock Synapse Helper.
+        mockSynapseHelper = mock(SynapseHelper.class);
 
         // Spy processor so we can mock out the rest call.
         processor = spy(new UserProcessor());
+        processor.setFileHelper(inMemoryFileHelper);
+        processor.setSynapseHelper(mockSynapseHelper);
 
         // Use a doAnswer(), so the tests can specify mockHttpResponse. The tests will also use verify() to validate
         // input args.
         doAnswer(invocation -> mockHttpResponse).when(processor).makeHttpRequest(any(), any());
 
         // Make request context.
-        ctx = new RequestContext(DATE_STRING, STUDY, mock(File.class));
+        ctx = new RequestContext(DATE_STRING, STUDY, tempDir);
     }
 
     @Test
@@ -281,5 +329,79 @@ public class UserProcessorTest {
         assertEquals(rowValueMap.get(Constants.COLUMN_HEALTH_CODE), HEALTH_CODE);
         assertEquals(rowValueMap.get(Constants.COLUMN_CREATED_DATE), DATE_STRING);
         assertEquals(rowValueMap.get(COLUMN_ID), expected);
+    }
+
+    @DataProvider(name = "serializeDataProvider")
+    public Object[][] serializeDataProvider() {
+        return new Object[][] {
+                { null, STRING_COLUMN, null },
+                { NullNode.instance, STRING_COLUMN, null },
+                { new IntNode(1), BOOLEAN_COLUMN, null },
+                { new TextNode("true"), BOOLEAN_COLUMN, null },
+                { BooleanNode.TRUE, BOOLEAN_COLUMN, "true" },
+                { new LongNode(1513152387123L), DATE_COLUMN, null },
+                { new TextNode("December 12, 2017 at 18:56:51"), DATE_COLUMN, null },
+                { new TextNode("2017-12-12T18:56:51.098Z"), DATE_COLUMN, "1513105011098" },
+                { new TextNode("3.14159"), DOUBLE_COLUMN, null },
+                { new DecimalNode(new BigDecimal("3.14159")), DOUBLE_COLUMN, "3.14159" },
+                { new IntNode(3), DOUBLE_COLUMN, "3" },
+                { new TextNode("42"), INTEGER_COLUMN, null },
+                { new IntNode(42), INTEGER_COLUMN, "42" },
+                { new DecimalNode(new BigDecimal("3.14159")), INTEGER_COLUMN, "3" },
+                { new IntNode(1024), STRING_COLUMN, "1024" },
+                { new TextNode("foo"), STRING_COLUMN, "foo" },
+                { new TextNode("aaaabbbbccccdddd"), STRING_COLUMN, "aaaabbbbcc" },
+                { new TextNode("foo"), UNSUPPORTED_COLUMN, null },
+        };
+    }
+
+    @Test(dataProvider = "serializeDataProvider")
+    public void serialize(JsonNode node, ColumnSchema columnSchema, String expected) throws Exception {
+        String result = processor.serializeJsonForColumn(ctx, node, columnSchema);
+        assertEquals(result, expected);
+    }
+
+    @Test
+    public void serializeLargeText() throws Exception {
+        ObjectNode node = DefaultObjectMapper.INSTANCE.createObjectNode();
+        node.put("foo", "foo-value");
+        node.put("bar", "bar-value");
+        String result = processor.serializeJsonForColumn(ctx, node, LARGETEXT_COLUMN);
+        assertEquals(result, node.toString());
+    }
+
+    @Test
+    public void serializeFileHandler() throws Exception {
+        // Mock Synapse Helper. We need to capture the file bytes while it's being uploaded, because we delete the file
+        // immediately afterwards.
+        when(mockSynapseHelper.createFileHandleWithRetry(any())).thenAnswer(invocation -> {
+            // Save file bytes
+            File uploadedFile = invocation.getArgumentAt(0, File.class);
+            uploadedFileBytes = inMemoryFileHelper.getBytes(uploadedFile);
+
+            // Mock and return file handle
+            FileHandle mockFileHandle = mock(FileHandle.class);
+            when(mockFileHandle.getId()).thenReturn(FILEHANDLE_ID);
+            return mockFileHandle;
+        });
+
+        // Set up JSON value
+        ObjectNode node = DefaultObjectMapper.INSTANCE.createObjectNode();
+        node.put("foo", "foo-value");
+        node.put("bar", "bar-value");
+
+        // Execute and validate
+        String result = processor.serializeJsonForColumn(ctx, node, FILEHANDLE_COLUMN);
+        assertEquals(result, FILEHANDLE_ID);
+
+        // Validate uploaded file contents
+        JsonNode uploadedNode = DefaultObjectMapper.INSTANCE.readTree(uploadedFileBytes);
+        assertEquals(uploadedNode, node);
+
+        // Make sure we deleted the file when we are done
+        ArgumentCaptor<File> uploadedFileCaptor = ArgumentCaptor.forClass(File.class);
+        verify(mockSynapseHelper).createFileHandleWithRetry(uploadedFileCaptor.capture());
+        File uploadedFile = uploadedFileCaptor.getValue();
+        assertFalse(inMemoryFileHelper.fileExists(uploadedFile));
     }
 }


### PR DESCRIPTION
Heart Rate intra day data is occasionally too big for a LargeText, so we need to move it to a file handle.

Pre-req: https://github.com/Sage-Bionetworks/bridge-base/pull/39

Testing done:
* mvn verify (unit tests, Findbugs, Jacoco test coverage)
* manually tested - Renamed the old dataset column and ran the worker to make sure we could export new data while keeping the old (renamed) data intact.
* integ tests